### PR TITLE
Filepicker: Ask for Player.log

### DIFF
--- a/src/app/ipc_main.ts
+++ b/src/app/ipc_main.ts
@@ -377,7 +377,7 @@ export function setupIpcMain(app: App): void {
 
   onMessageFromBrowserWindow('set-log-path', () => {
     dialog
-      .showOpenDialog({properties: ['openFile'], filters: [{name: 'output_*', extensions: ['txt']}]})
+      .showOpenDialog({properties: ['openFile'], filters: [{name: 'Player', extensions: ['log']}]})
       .then((log) => {
         if (!log.canceled && log.filePaths[0]) {
           settingsStore.get().logPath = log.filePaths[0];


### PR DESCRIPTION
The current version fails at accepting (or rather asking for) the correct log file. This PR is aimed at fixing that.