### PR TITLE
[bugfix] lands total twice counting fix

### DIFF
--- a/src/windows/overlay/functions/drawdeck.ts
+++ b/src/windows/overlay/functions/drawdeck.ts
@@ -8,6 +8,10 @@ export function drawDeck(): void {
   let output = '';
   let myBestFirstCard = 0;
   let myWorstFirstCard = 0;
+  currentMatch.lands.clear();
+  currentMatch.landsLeft.clear();
+  currentMatch.basicLands.clear();
+  currentMatch.basicLandsLeft.clear();
   currentMatch.myFullDeck.forEach((card) => {
     const FirstHandEval = overlayConfig.allCards.get(card.card)?.wleval_1sthand;
     if (FirstHandEval !== undefined) {


### PR DESCRIPTION
This fixes an issue with drawDeck() called multiple times resulting in lands total counted multiple times thus showing incorrect total in overlay